### PR TITLE
Use env vars for setting up the DB; Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,33 @@ After opening the project in your IDE, you can run it using
 npm start run
 ```
 
+### Setting up database:
+Make sure `PostgreSQL` is installed. After installation, start `PostgreSQL` and run the command
+```
+CREATE DATABASE acai;
+```
+If you get a database error, upon running `npm start` and you already have the database created try
+```
+DROP DATABASE acai;
+CREATE DATABASE acai;
+```
+Connect to the database by running
+```
+psql acai
+```
+
 ### Environment Variables:
 It is recommended to use [`autoenv`](https://github.com/kennethreitz/autoenv). The required environment variables for this API are the following:
-````bash
+```bash
 export PORT=8000
-export ACCESS_TOKEN=FILL IN
-````
+export ACCESS_TOKEN=FILL_IN
+export DB_USERNAME=FILL_IN
+export DB_PASSWORD=FILL_IN
+export DB_HOST=localhost
+export DB_NAME=acai
+export DB_PORT=5432
+export NODE_ENV=development
+```
 
 ## Configuration (optional)
 We recommend using TSLint (deprecrated) for linting. If you are using VSCode, it can be downloaded directly through the Extensions panel. 

--- a/ormconfig.json
+++ b/ormconfig.json
@@ -1,11 +1,4 @@
 {
-   "type": "postgres",
-   "host": "localhost",
-   "port": 5432,
-   "username": "postgres",
-   "password": "postgres",
-   "database": "acai",
-   "synchronize": true,
    "logging": false,
    "entities": [
       "src/entities/**/*.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -266,6 +266,14 @@
         "@types/node": "*"
       }
     },
+    "@types/dotenv": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-6.1.0.tgz",
+      "integrity": "sha512-gmbNb7V1LbJQA4MmH0hVFgqY1cyKsa6RvKC1Xrq0WBnZ0JuuvXKciXx/s8dN0LVXCJd8xO6wIaSFSyUIoGph9g==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/express": {
       "version": "4.16.1",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.1.tgz",
@@ -2503,9 +2511,9 @@
       }
     },
     "dotenv": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
-      "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g=="
     },
     "duplexify": {
       "version": "3.7.1",
@@ -3526,8 +3534,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3548,14 +3555,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3570,20 +3575,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3700,8 +3702,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3713,7 +3714,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3728,7 +3728,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3736,14 +3735,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3762,7 +3759,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3843,8 +3839,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3856,7 +3851,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3942,8 +3936,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3979,7 +3972,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3999,7 +3991,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4043,14 +4034,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -8486,6 +8475,11 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "dotenv": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+          "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
         },
         "ms": {
           "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
   },
   "dependencies": {
     "@types/body-parser": "^1.17.0",
+    "@types/dotenv": "^6.1.0",
     "@types/express": "^4.16.1",
     "@types/node": "^11.9.4",
+    "dotenv": "^7.0.0",
     "express": "^4.16.4",
     "http": "0.0.0",
     "merge": "^1.2.1",

--- a/src/db/DbConnection.ts
+++ b/src/db/DbConnection.ts
@@ -1,0 +1,30 @@
+// @flow
+import { Connection, ConnectionOptions, createConnection } from 'typeorm';
+
+import Transaction from '../entities/Transaction';
+import User from '../entities/User';
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+const entities = [
+  Transaction,
+  User,
+];
+
+const connectionOptions: ConnectionOptions = {
+  entities,
+  type: 'postgres',
+  host: process.env.DB_HOST,
+  port: isProduction ? Number(process.env.DB_PORT) : 5432,
+  username: process.env.DB_USERNAME,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  synchronize: true,
+  extra: {
+    ssl: isProduction,
+  },
+};
+
+const dbConnection = (): Promise<Connection> => createConnection(connectionOptions);
+
+export default dbConnection;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,13 +1,16 @@
+import dotenv from 'dotenv';
 import 'reflect-metadata';
-import { createConnection } from 'typeorm';
 import API from './API';
+import DBConnection from './db/DBConnection';
 
 const app = new API();
 const server = app.getServer(false);
 const PORT: number = +process.env.PORT || 5000;
 const SERVER_ADDRESS: string = '0.0.0.0';
 
-createConnection().then(async (connection: any) => {
+dotenv.config(); // establish env variables
+
+DBConnection().then(async (connection: any) => {
   app.express.listen(PORT, () => {
     console.log(
       `App is running on ${SERVER_ADDRESS}:${PORT}...`,


### PR DESCRIPTION
I moved the database config from the `ormconfig.json` to env vars since this will be hard to change to deploy. Also, updated the README with more info on setting up the database and adding env vars