### PR TITLE
Edit case of SquareAPI import

### DIFF
--- a/src/routers/OrderHistoryRouter.ts
+++ b/src/routers/OrderHistoryRouter.ts
@@ -2,7 +2,7 @@ import { Request } from 'express';
 import UsersRepo from '../repos/UsersRepo';
 
 import ApplicationRouter from '../appdev/ApplicationRouter';
-import squareAPI from '../common/squareAPI';
+import SquareAPI from '../common/SquareAPI';
 import utils from '../common/utils';
 
 class OrderHistoryRouter extends ApplicationRouter<any> {
@@ -22,7 +22,7 @@ class OrderHistoryRouter extends ApplicationRouter<any> {
       (ids, transaction) => ids.concat([transaction.orderID]),
       [],
     );
-    const orders = (await squareAPI.fetchOrders(orderIDs)).orders;
+    const orders = (await SquareAPI.fetchOrders(orderIDs)).orders;
     return { orders };
   }
 }


### PR DESCRIPTION
The dev server wouldn't start due to the import using `squareAPI` instead of `SquareAPI`. This fix is currently deployed on the dev server